### PR TITLE
Fix the Test Results Path

### DIFF
--- a/.github/workflows/graphics_tests.yml
+++ b/.github/workflows/graphics_tests.yml
@@ -49,7 +49,7 @@ jobs:
         with:
           name: test_results
           path: |
-            '**/build/test-results/**/TEST-*.xml'
-            '**/roborazzi/build/reports/*'
-            '**/roborazzi/src/screenshots/*'
-            '**/roborazzi/build/outputs/roborazzi/*'
+            **/build/test-results/**/TEST-*.xml
+            **/roborazzi/build/reports/*
+            **/roborazzi/src/screenshots/*
+            **/roborazzi/build/outputs/roborazzi/*


### PR DESCRIPTION
### Overview
The 'Upload Test Results' step in graphics_tests.yml incorrectly used a single quotation mark for specifying multiple paths. 

### Proposed Changes
I have corrected this to align with the official documentation for actions/upload-artifact.
